### PR TITLE
Update Zipkin Server jar Maven coordinates and use quickstart script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Each module will also have different minimum variables that need to be set.
 Here's an example of integrating the scouter Collector.
 
 ### Step 1: Download zipkin-server jar
-Download the [latest released server](https://search.maven.org/remote_content?g=io.zipkin.java&a=zipkin-server&v=LATEST&c=exec) as zipkin.jar:
+Download the [latest released server](https://search.maven.org/remote_content?g=io.zipkin&a=zipkin-server&v=LATEST&c=exec) as zipkin.jar:
 
 ```
 cd /tmp
-wget -O zipkin.jar 'https://search.maven.org/remote_content?g=io.zipkin.java&a=zipkin-server&v=LATEST&c=exec'
+curl -sSL https://zipkin.io/quickstart.sh | bash -s
 ```
 
 ### Step 2: Download the latest zipkin-storage-scouter jar


### PR DESCRIPTION
The latest versions of the Zipkin Server jar are published with a different group ID. This updates the download link and makes use of the Zipkin quickstart script.

Related to https://github.com/openzipkin/openzipkin.github.io/issues/136